### PR TITLE
BugFix 50650: Generate inoperative with specific template.

### DIFF
--- a/{{cookiecutter.project_slug}}/shell-definition.yaml
+++ b/{{cookiecutter.project_slug}}/shell-definition.yaml
@@ -14,7 +14,7 @@ imports:
 
 node_types:
   vendor.resource.{{cookiecutter.display_name}}:
-    derived_from: cloudshell.nodes.GenericResource
+    derived_from: cloudshell.nodes.GenericConnectableResource
     #properties:
     #  my_property:
     #    type: string          # optional values: string, integer, float, boolean, cloudshell.datatypes.Password


### PR DESCRIPTION
The error was caused due to the wrong node type. Need to use "GenericConnectableResource", not a  base "GenericResource".